### PR TITLE
allow Collector to count duplicated cards

### DIFF
--- a/js/deck.js
+++ b/js/deck.js
@@ -370,13 +370,12 @@ var deck = {
         for (const card of hand.nonBlankedCards()) {
           var suit = card.suit;
           if (bySuit[suit] === undefined) {
-            bySuit[suit] = {};
+            bySuit[suit] = 0
           }
-          bySuit[suit][card.name] = card;
+          bySuit[suit]++
         }
         var bonus = 0;
-        for (const suit of Object.values(bySuit)) {
-          var count = Object.keys(suit).length;
+        for (const count of Object.values(bySuit)) {
           if (count === 3) {
             bonus += 10;
           } else if (count === 4) {

--- a/js/tests.js
+++ b/js/tests.js
@@ -15,6 +15,7 @@ $(document).ready(function() {
   assertScoreByCode('24,53+53:24', 26, '2 Dwarvish Infantries should penalty eachother');
   assertScoreByCode('9,12,16,37+9:16', 95, 'Island can be used even when blanked');
   assertScoreByCode('10,53+53:10', 23, 'Elementals count their Doppelgänger');
+  assertScoreByCode('26,46,47,51,53+51:46,53:46', 60, 'Collector scores duplicated cards');
   assertScoreByCode('26,27,30,36,38,39,40+', 193, 'Collector can score multiple sets');
   assertScoreByCode('22,31,36,43,44,46,47+', 206, 'Gem of Order can score multiple sets')
 });


### PR DESCRIPTION
There's an ambiguity in the way the Collector interacts with wild cards. The bonus text says "different cards", but it's not immediately clear what that means. I.e., if you have one card in a suit and then duplicate it with a Doppelgänger, Shapshifter, or Mirage, have you now collected two items in that suit, or still only one?

The argument for two items is:

  - you now have two physically different cards which both have that suit

  - that's how the WizKids app scores it

The argument for one item is:

  - the cards are not "different" cards, in that they have the same name

  - Bruce Glassco says so (multiple times):

      - https://boardgamegeek.com/thread/1838508/article/26773487#26773487

      - https://boardgamegeek.com/thread/1911765/article/28414416#28414416

I wrote this patch after researching how the WizKids app scores it. But now after seeing Bruce's comments, I'm inclined to say it is the wrong thing (and your scoring is correct and WizKids has a bug). However, I thought I'd throw it out here for posterity and the sake of discussion. Possibly it could become a "house rule" option, but I'm not sure you'd want to clutter up the interface with that.
